### PR TITLE
use initials, batch combat logs, show heals in combat logs

### DIFF
--- a/app/components/Tokens_Layer.tsx
+++ b/app/components/Tokens_Layer.tsx
@@ -14,6 +14,13 @@ type Props = {
   isDmView?: boolean;
 };
 
+const characterInitials = (name: string) => {
+  const parts = name.trim().split(' ');
+  if (parts.length === 0) return '';
+  if (parts.length === 1) return parts[0].charAt(0).toUpperCase();
+  return (parts[0].charAt(0) + parts[1].charAt(0)).toUpperCase();
+};
+
 export default function Tokens_Layer({
   characters,
   cellPx,
@@ -106,7 +113,7 @@ export default function Tokens_Layer({
             aria-label={char.name}
             role="button"
           >
-            <span className="text-xs text-white font-medium">{char.name.charAt(0)}</span>
+            <span className="text-xs text-white font-medium">{characterInitials(char.name)}</span>
 
             {char.isDead && (
               <div className="absolute inset-0 flex items-center justify-center">

--- a/app/hooks/rtc/useHostMap.ts
+++ b/app/hooks/rtc/useHostMap.ts
@@ -120,7 +120,7 @@ export function useHostPeerSession({mapName, moveCharacterCallback}: {mapName: s
       const snap = data as SnapshotUpdate;
       setGameState(snap.snapShot);
       console.log('message count', messageCount);
-      console.log('ref count', connectionsRef.current.length);
+      // console.log('ref count', connectionsRef.current.length);
     }
 
     connectionsRef.current.forEach((conn) => {

--- a/app/map/components/CombatLog/index.tsx
+++ b/app/map/components/CombatLog/index.tsx
@@ -37,9 +37,12 @@ export function CombatLog({ damageLog, maxEvents = 10 }: CombatLogProps) {
               className={`${styles.combatLogEvent} ${index === 0 ? styles.mostRecent : ''}`}
             >
               <span className={styles.eventCharacter}>{event.characterName}</span>
-              <span className={styles.eventText}> hit for </span>
-              <span className={styles.eventDamage}>{event.amount}</span>
-              <span className={styles.eventText}> damage</span>
+              <span className={styles.eventText}>
+                {' '}
+                {event.amount > 0 ? ' hit for ' : ' healed for '}{' '}
+              </span>
+              <span className={styles.eventDamage}>{Math.abs(event.amount)}</span>
+              <span className={styles.eventText}> {event.amount > 0 ? ' damage' : ' HP'}</span>
 
               {event.round !== undefined && (
                 <span className={styles.eventRound}> (Round {event.round})</span>


### PR DESCRIPTION
This PR 
- updates the character tokens to use the initials of the first two words in a characters name, instead of just the first letter
- debounces the combat log so that it batches changes to the character's HP 
- the combat log on the player side shows healing appropriately: `Character hit for -5 damage` => `Character healed for 5 HP`